### PR TITLE
Fix not installing on Python 3.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,10 @@ matrix:
       env: PYTHON=3.6.9 PY=3.6
     - os: osx
       language: generic
-      env: PYTHON=3.7.5 PY=3.7
+      env: PYTHON=3.7.9 PY=3.7
+    - os: osx
+      language: generic
+      env: PYTHON=3.8.8 PY=3.8
     - sudo: required
       services:
         - docker

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+include LISCENSE
+include README.rst
+include MANIFEST.in
+include requirements*.txt
+include conftest.py
+
+exclude travis www
+recursive-exclude travis *
+recursive-exclude www *
+exclude *.yml
+exclude *.bash
+exclude pypi_notes.txt
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]


### PR DESCRIPTION
This PR will fix #9 by adding a MANIFEST.in file that includes the requirements.txt file in all distributions.
Also, I added Python 3.8 testing to Travis CI.

After merging this, make sure to increase the version number in `__version__.py` to `0.4.1` to trigger a new release.

EDIT: It seems that Travis CI testing is only enabled for the `astroduff` fork and not this one.
That will have to be fixed first then.