### PR TITLE
minor improvements to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 CosmoloPy 
 =========
 
-a cosmology package for Python
+A cosmology package for Python.
 
 For documentation and installation instructions, see
 http://roban.github.com/CosmoloPy/
@@ -38,7 +38,7 @@ For power spectrum calculation (needed for most of perturbation module):
 Installation from PyPI
 ======================
 
-You can easily install the pacakge directly from the Python Package
+If you use Python 3.5–3.7 on Linux, you can easily install the package directly from the Python Package
 Index with pip.
 
 Run with:
@@ -48,7 +48,9 @@ Run with:
 Installation from Source
 ========================
 
-If you've downloaded the source, first install Swig-3 or later and then 
+If you use a different operating system or a more recent version of Python,
+you first need to install `SWIG <https://github.com/swig/swig/>`_ v3 or later.
+Then, download the CosmoloPy source and
 install it by running (in CosmoloPy folder)
 
     > pip install . 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ For power spectrum calculation (needed for most of perturbation module):
 Installation from PyPI
 ======================
 
-If you use Python 3.5–3.7 on Linux, you can easily install the package directly from the Python Package
+You can easily install the package directly from the Python Package
 Index with pip.
 
 Run with:
@@ -48,10 +48,8 @@ Run with:
 Installation from Source
 ========================
 
-If you use a different operating system or a more recent version of Python,
-you first need to install `SWIG <https://github.com/swig/swig/>`_ v3 or later.
-Then, download the CosmoloPy source and
-install it by running (in CosmoloPy folder)
+To install from source, you first need to install `SWIG <https://github.com/swig/swig/>`_ v3 or later.
+Then, download the CosmoloPy source and install it by running (in CosmoloPy folder)
 
     > pip install . 
 
@@ -76,4 +74,4 @@ Contributors
 ============
 
 - Python 3 implementation by @JohannesBuchner and @1313e 
-- Automated PyPI deployment on Travis by @1313e
+- Automated PyPI deployment on GitHub Actions by @1313e


### PR DESCRIPTION
Thanks for the very fast fix to #9!
Unfortunately, it seems that [v0.4.1 on PyPI](https://pypi.org/project/cosmolopy/0.4.1/#files) doesn’t have pre-built packages for macOS any more ([which v0.4.0 did](https://pypi.org/project/cosmolopy/0.4.0/#files)); plus, even on Linux pre-built packages are still only available up to Python 3.7.

I don’t know Travis well enough to fix that. If you can, that would be ideal; as a backup, in this PR I’ve added a note to the README to hopefully save others some confusion. (I also fixed a typo and added a link to SWIG.)