### PR TITLE
resolve error when running with python -OO

### DIFF
--- a/cosmolopy/constants.py
+++ b/cosmolopy/constants.py
@@ -84,6 +84,7 @@ sigma_T_cm = 6.6524586e-25 # cm^2
 doc += "  sigma_T_cm: Thomson cross section in Mpc^2\n"
 sigma_T_Mpc = sigma_T_cm / (Mpc_cm ** 2.) # Mpc^2 
 
-__doc__ += "\n".join(sorted(doc.split("\n")))
+if __doc__ is not None:
+    __doc__ += "\n".join(sorted(doc.split("\n")))
 
 

--- a/cosmolopy/distance.py
+++ b/cosmolopy/distance.py
@@ -37,7 +37,7 @@ def set_omega_k_0(cosmo):
     """Returns the cosmo dictionary with omega_k_0 set.
     See get_omega_k_0.
     
-    Note that cosmo is not passed as \*\*cosmo for once. This function
+    Note that cosmo is not passed as \\*\\*cosmo for once. This function
     modifies the dictionary in place and returns the result.
 
     """


### PR DESCRIPTION
running python with optimizations turned on strips away `__doc__` and leads to an error:
```bash
python3 -OO -c 'import cosmolopy'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/mnt/data/daten/PostDoc2/home/Downloads/CosmoloPy3/cosmolopy/__init__.py", line 91, in <module>
    from . import constants as cc
  File "/mnt/data/daten/PostDoc2/home/Downloads/CosmoloPy3/cosmolopy/constants.py", line 88, in <module>
    __doc__ += "\n".join(sorted(doc.split("\n")))
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
```
This PR resolves this.

Also, there is a syntaxwarning about backslash escape, which I also addressed.